### PR TITLE
Multiple simultaneous i18n translations support

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -24,7 +24,8 @@ var dateFormat = function () {
 		};
 
 	// Regexes and supporting functions are cached through closure
-	return function (date, mask, utc) {
+	return function (date, mask, utc, i18n) {
+		i18n = i18n ? i18n : "en";
 		var dF = dateFormat;
 
 		// You can't provide utc if you skip other args (use the "UTC:" mask prefix)
@@ -64,12 +65,12 @@ var dateFormat = function () {
 			flags = {
 				d:    d,
 				dd:   pad(d),
-				ddd:  dF.i18n.dayNames[D],
-				dddd: dF.i18n.dayNames[D + 7],
+				ddd:  dF.i18n[i18n].dayNames[D],
+				dddd: dF.i18n[i18n].dayNames[D + 7],
 				m:    m + 1,
 				mm:   pad(m + 1),
-				mmm:  dF.i18n.monthNames[m],
-				mmmm: dF.i18n.monthNames[m + 12],
+				mmm:  dF.i18n[i18n].monthNames[m],
+				mmmm: dF.i18n[i18n].monthNames[m + 12],
 				yy:   String(y).slice(2),
 				yyyy: y,
 				h:    H % 12 || 12,
@@ -115,14 +116,16 @@ dateFormat.masks = {
 
 // Internationalization strings
 dateFormat.i18n = {
-	dayNames: [
-		"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
-		"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
-	],
-	monthNames: [
-		"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-		"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-	]
+	"en": {
+		dayNames: [
+			"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+			"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+		],
+		monthNames: [
+			"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+			"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+		]
+	}
 };
 
 /*


### PR DESCRIPTION
Hello Felix,

I'd like to use this library at the start-up I'm part of, but we need to support multiple languages for our users (starting with English and Spanish, with immediate plans to expand to Portuguese, French, and Italian shortly after launch), and swapping the i18n object on every `request` isn't a nice solution, so I've patched the i18n object to be a hash table of [ISO 639-1 codes](http://en.wikipedia.org/wiki/ISO_639-1) (though you could always use 639-2 if need be; no restriction enforced).

It's done through a nullable fourth parameter, so this won't break the usage of the dateformat function, but the restructuring of the i18n object would break others' code if they are replacing the object as it currently stands.

David
