### PR TITLE
Expires Header Format added

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -127,18 +127,19 @@ var dateFormat = function () {
 
 // Some common format strings
 dateFormat.masks = {
-	"default":      "ddd mmm dd yyyy HH:MM:ss",
-	shortDate:      "m/d/yy",
-	mediumDate:     "mmm d, yyyy",
-	longDate:       "mmmm d, yyyy",
-	fullDate:       "dddd, mmmm d, yyyy",
-	shortTime:      "h:MM TT",
-	mediumTime:     "h:MM:ss TT",
-	longTime:       "h:MM:ss TT Z",
-	isoDate:        "yyyy-mm-dd",
-	isoTime:        "HH:MM:ss",
-	isoDateTime:    "yyyy-mm-dd'T'HH:MM:ss",
-	isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
+	"default":           "ddd mmm dd yyyy HH:MM:ss",
+	shortDate:           "m/d/yy",
+	mediumDate:          "mmm d, yyyy",
+	longDate:            "mmmm d, yyyy",
+	fullDate:            "dddd, mmmm d, yyyy",
+	shortTime:           "h:MM TT",
+	mediumTime:          "h:MM:ss TT",
+	longTime:            "h:MM:ss TT Z",
+	isoDate:             "yyyy-mm-dd",
+	isoTime:             "HH:MM:ss",
+	isoDateTime:         "yyyy-mm-dd'T'HH:MM:ss",
+	isoUtcDateTime:      "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'",
+	expiresHeaderFormat: "ddd, dd mmm yyyy HH:MM:ss Z"
 };
 
 // Internationalization strings


### PR DESCRIPTION
Like your library.  Just wanted to contribute a convenience format to keep me from having to keep looking it up.  

I'm not sure if the expires header requires you submit the timezone as GMT (which is equivalent of course to UTC)  but I'm not sure if all browsers it requires GMT In the string in order to behave correctly.

Right now "expiresHeaderFormat" would produce a string ending in UTC but otherwise in the correct format assuming you executed it like.

dateFormat(now, "expiresHeader", true)
