### PR TITLE
Add repository section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   "devDependencies": {},
   "engines": {
     "node": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felixge/node-dateformat.git"
   }
 }


### PR DESCRIPTION
The absence of the section causes warning in newer npm versions.
