### PR TITLE
Support "GMT:" prefix in addition to "UTC:"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ As taken from Steven's post, modified to match the Modifications listed above:
     dateFormat(now, "longTime", true);
     // 10:46:21 PM UTC
 
-    // ...Or add the prefix "UTC:" to your mask.
+    // ...Or add the prefix "UTC:" or "GMT:" to your mask.
     dateFormat(now, "UTC:h:MM:ss TT Z");
     // 10:46:21 PM UTC
 

--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -61,7 +61,7 @@ var dateFormat = function () {
     };
 
 	// Regexes and supporting functions are cached through closure
-	return function (date, mask, utc) {
+	return function (date, mask, utc, gmt) {
 		var dF = dateFormat;
 
 		// You can't provide utc if you skip other args (use the "UTC:" mask prefix)
@@ -82,10 +82,14 @@ var dateFormat = function () {
 
 		mask = String(dF.masks[mask] || mask || dF.masks["default"]);
 
-		// Allow setting the utc argument via the mask
-		if (mask.slice(0, 4) == "UTC:") {
+		// Allow setting the utc/gmt argument via the mask
+		var maskSlice = mask.slice(0, 4);
+		if (maskSlice == "UTC:" || maskSlice == "GMT:") {
 			mask = mask.slice(4);
 			utc = true;
+			if (maskSlice == "GMT:") {
+				gmt = true;
+			}
 		}
 
 		var	_ = utc ? "getUTC" : "get",
@@ -125,7 +129,7 @@ var dateFormat = function () {
 				tt:   H < 12 ? "am" : "pm",
 				T:    H < 12 ? "A"  : "P",
 				TT:   H < 12 ? "AM" : "PM",
-				Z:    utc ? "UTC" : (String(date).match(timezone) || [""]).pop().replace(timezoneClip, ""),
+				Z:    gmt ? "GMT" : utc ? "UTC" : (String(date).match(timezone) || [""]).pop().replace(timezoneClip, ""),
 				o:    (o > 0 ? "-" : "+") + pad(Math.floor(Math.abs(o) / 60) * 100 + Math.abs(o) % 60, 4),
 				S:    ["th", "st", "nd", "rd"][d % 10 > 3 ? 0 : (d % 100 - d % 10 != 10) * d % 10],
 				W:    W,


### PR DESCRIPTION
Since the two are casually interchangeable, allow "GMT:" prefix to be used.
UTC is obviously preferred, but some systems require the older standard.
