### PR TITLE
Fix issue 15: "Week calculation is wrong ... includes decimals"

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -46,7 +46,7 @@ var dateFormat = function () {
 
       // Number of weeks between target Thursday and first Thursday
       var weekDiff = (targetThursday - firstThursday) / (86400000*7);
-      return 1 + weekDiff;
+      return 1 + Math.floor(weekDiff);
     },
 
     /**


### PR DESCRIPTION
According to the updated article,
http://techblog.procurios.nl/k/n618/news/view/33796/14863/calculate-iso-8601-week-and-year-in-javascript.html
either ceil or floor is needed. Choosing to use floor to keep the +1.
