### PR TITLE
hundredth corrected: divide millis through 10

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -124,7 +124,7 @@ var dateFormat = function () {
 				s:    s,
 				ss:   pad(s),
 				l:    pad(L, 3),
-				L:    pad(L > 99 ? Math.round(L / 10) : L),
+				L:    pad(Math.round(L / 10)),
 				t:    H < 12 ? "a"  : "p",
 				tt:   H < 12 ? "am" : "pm",
 				T:    H < 12 ? "A"  : "P",


### PR DESCRIPTION
Milliseconds must divided through 10 in every case.
The first 99 millis dont mean hundredth from 0 to 99, but 0 to 10.
