### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "Christoph Tavan <dev@tavan.de>"
   ],
   "version": "1.0.8",
+  "licenses" : [
+    {
+      "type" : "MIT",
+      "url" : "https://raw.githubusercontent.com/felixge/node-dateformat/master/LICENSE"
+    }
+  ],
   "main": "./lib/dateformat",
   "dependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
Allows license to be read programatically.
