### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "Christoph Tavan <dev@tavan.de>"
   ],
   "version": "1.0.11",
-  "licenses": {
-    "type": "MIT",
-    "url": "https://raw.githubusercontent.com/felixge/node-dateformat/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "lib/dateformat",
   "bin": {
     "dateformat": "bin/cli.js"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/