### PR TITLE
Fix incorrect work with double-quoted substrings.

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -16,7 +16,7 @@
   'use strict';
 
   var dateFormat = (function() {
-      var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|'[^']*'|'[^']*'/g;
+      var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|"[^"]*"|'[^']*'/g;
       var timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
       var timezoneClip = /[^-+\dA-Z]/g;
   

--- a/test/test_quotes.js
+++ b/test/test_quotes.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+
+var dateFormat = require('./../lib/dateformat');
+
+describe('quoted substrings', function() {
+  var az = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  it('should not format single quoted substrings removing quotes', function() {
+    var result = dateFormat("'" + az + "'");
+    assert.strictEqual(result, az);
+  });
+
+  it('should not format double quoted substrings removing quotes', function() {
+    var result = dateFormat('"' + az + '"');
+    assert.strictEqual(result, az);
+  });
+});
+


### PR DESCRIPTION
Their content was not ignored. Original [function](http://blog.stevenlevithan.com/archives/date-time-format) works correctly.
```js
// correct
dateFormat('2017-06-16', "'yyyy'") // yyyy

// wrong
dateFormat('2017-06-16', '"yyyy"') // "2017"
```