### PR TITLE
no need to mention standalone function any more

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,7 @@ dateFormat.masks.hammerTime = 'HH:MM! "Can\'t touch this!"';
 dateFormat(now, "hammerTime");
 // 17:46! Can't touch this!
 
-// When using the standalone dateFormat function,
-// you can also provide the date as a string
+// You can also provide the date as a string
 dateFormat("Jun 9 2007", "fullDate");
 // Saturday, June 9, 2007
 


### PR DESCRIPTION
There's no need to mention standalone function in the Readme, because standalone is the only thing that exists now (`Date.prototype.format` was removed).