### PR TITLE
changed to use the epoch time if first arguments is 0.

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -29,7 +29,7 @@
           date = undefined;
         }
   
-        date = date || new Date;
+        date = date || date === 0 ? date : new Date;
   
         if(!(date instanceof Date)) {
           date = new Date(date);

--- a/test/test_isoutcdatetime.js
+++ b/test/test_isoutcdatetime.js
@@ -6,6 +6,8 @@ describe('isoUtcDateTime', function() {
   it('should correctly format the timezone part', function(done) {
     var actual = dateFormat('2014-06-02T13:23:21-08:00', 'isoUtcDateTime');
     assert.strictEqual(actual, '2014-06-02T21:23:21Z');
+    var epochTime = dateFormat(0, 'isoUtcDateTime');
+    assert.strictEqual(epochTime, '1970-01-01T00:00:00Z');
     done();
   });
 });


### PR DESCRIPTION
fixed for https://github.com/felixge/node-dateformat/issues/79