### PR TITLE
Fix format `L`, to output floored value.

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -83,7 +83,7 @@
           s:    s,
           ss:   pad(s),
           l:    pad(L, 3),
-          L:    pad(Math.round(L / 10)),
+          L:    pad(Math.floor(L / 10)),
           t:    H < 12 ? dateFormat.i18n.timeNames[0] : dateFormat.i18n.timeNames[1],
           tt:   H < 12 ? dateFormat.i18n.timeNames[2] : dateFormat.i18n.timeNames[3],
           T:    H < 12 ? dateFormat.i18n.timeNames[4] : dateFormat.i18n.timeNames[5],


### PR DESCRIPTION
Format mask `L` is documented as `Milliseconds; gives 2 digits`.

However, current implementation outputs 3 digits when millisecond is between 995-999, due to the lib uses [Math.round(L / 10)](https://github.com/felixge/node-dateformat/blob/c7fb1bc73fd1180df0b9670e83796ea14963298d/lib/dateformat.js#L86) and outputs `100` in this case.

This should be `Math.floor` instead of `Math.round`.