### PR TITLE
Make maintainers an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dateformat",
   "description": "A node.js package for Steven Levithan's excellent dateFormat() function.",
-  "maintainers": "Felix Geisendörfer <felix@debuggable.com>",
+  "maintainers": ["Felix Geisendörfer <felix@debuggable.com>"],
   "homepage": "https://github.com/felixge/node-dateformat",
   "author": "Steven Levithan",
   "contributors": [


### PR DESCRIPTION
See npm/npm#11056 for examples of npm issues that can arise when maintainers is not an array.