### PR TITLE
Update time zone abbreviations

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -15,7 +15,7 @@
 (function (global) {
   const dateFormat = (() => {
     const token = /d{1,4}|D{3,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|W{1,2}|[LlopSZN]|"[^"]*"|'[^']*'/g;
-    const timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
+    const timezone = /\b(?:[A-Z]{1,3}[A-Z]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
     const timezoneClip = /[^-+\dA-Z]/g;
 
     // Regexes and supporting functions are cached through closure

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -15,7 +15,7 @@
 (function (global) {
   const dateFormat = (() => {
     const token = /d{1,4}|D{3,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|W{1,2}|[LlopSZN]|"[^"]*"|'[^']*'/g;
-    const timezone = /\b((?:[A-Z]{1,3}[A-Z][TC])(?:[-+]\d{4})?|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time)\b/g;
+    const timezone = /\b(?:[A-Z]{1,3}[A-Z][TC])(?:[-+]\d{4})?|((?:Australian )?(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time)\b/g;
     const timezoneClip = /[^-+\dA-Z]/g;
 
     // Regexes and supporting functions are cached through closure

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -15,7 +15,7 @@
 (function (global) {
   const dateFormat = (() => {
     const token = /d{1,4}|D{3,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|W{1,2}|[LlopSZN]|"[^"]*"|'[^']*'/g;
-    const timezone = /\b(?:[A-Z]{1,3}[A-Z]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
+    const timezone = /\b((?:[A-Z]{1,3}[A-Z][TC])(?:[-+]\d{4})?|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time)\b/g;
     const timezoneClip = /[^-+\dA-Z]/g;
 
     // Regexes and supporting functions are cached through closure


### PR DESCRIPTION
Uses list of time zone abbreviations. https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations

I expanded the regular expression to use all time zone abbreviations.

As an example `AEST` time zones are being clipped to just `EST`. This change fixes that problem. It also fixes unreported problems with other time zones. According to Wikipedia the longest time zone is five characters.