### PR TITLE
Fixed Issue with Benchmarking

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -14,8 +14,8 @@ const masks = [
 let results = [];
 
 masks.forEach((mask) => {
-  const previousSpeed = getSpeed(true, mask);
-  const newSpeed = getSpeed(false, mask);
+  const previousSpeed = getSpeed(false, mask);
+  const newSpeed = getSpeed(true, mask);
   results.push({
     mask: mask,
     previous: previousSpeed + "ms",


### PR DESCRIPTION
The New column showed the old speeds and the Old column showed the new speeds.  
These were swapped and are now corrected.

closes #120