### PR TITLE
Remove lib From Source Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ vendor
 build
 dest
 dist
+lib
 lib-cov
 coverage
 nbproject


### PR DESCRIPTION
Lib should only be generated when the app builds.
And so the contents of it should not be stored in source control.

closed #124 