### PR TITLE
Convert Functions to Using Arrow Functions

### DIFF
--- a/benchmark/previousDateFormat.js
+++ b/benchmark/previousDateFormat.js
@@ -1,3 +1,24 @@
+"use strict";
+
+function _typeof(obj) {
+  "@babel/helpers - typeof";
+  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+    _typeof = function _typeof(obj) {
+      return typeof obj;
+    };
+  } else {
+    _typeof = function _typeof(obj) {
+      return obj &&
+        typeof Symbol === "function" &&
+        obj.constructor === Symbol &&
+        obj !== Symbol.prototype
+        ? "symbol"
+        : typeof obj;
+    };
+  }
+  return _typeof(obj);
+}
+
 /*
  * Date Format 1.2.3
  * (c) 2007-2009 Steven Levithan <stevenlevithan.com>
@@ -11,16 +32,14 @@
  * The date defaults to the current date/time.
  * The mask defaults to dateFormat.masks.default.
  */
-
 (function (global) {
   "use strict";
 
   var dateFormat = (function () {
     var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|"[^"]*"|'[^']*'/g;
     var timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
-    var timezoneClip = /[^-+\dA-Z]/g;
+    var timezoneClip = /[^-+\dA-Z]/g; // Regexes and supporting functions are cached through closure
 
-    // Regexes and supporting functions are cached through closure
     return function (date, mask, utc, gmt) {
       // You can't provide utc if you skip other args (use the 'UTC:' mask prefix)
       if (
@@ -44,78 +63,184 @@
 
       mask = String(
         dateFormat.masks[mask] || mask || dateFormat.masks["default"]
-      );
+      ); // Allow setting the utc/gmt argument via the mask
 
-      // Allow setting the utc/gmt argument via the mask
       var maskSlice = mask.slice(0, 4);
+
       if (maskSlice === "UTC:" || maskSlice === "GMT:") {
         mask = mask.slice(4);
         utc = true;
+
         if (maskSlice === "GMT:") {
           gmt = true;
         }
       }
 
-      var _ = utc ? "getUTC" : "get";
-      var d = date[_ + "Date"]();
-      var D = date[_ + "Day"]();
-      var m = date[_ + "Month"]();
-      var y = date[_ + "FullYear"]();
-      var H = date[_ + "Hours"]();
-      var M = date[_ + "Minutes"]();
-      var s = date[_ + "Seconds"]();
-      var L = date[_ + "Milliseconds"]();
-      var o = utc ? 0 : date.getTimezoneOffset();
-      var W = getWeek(date);
-      var N = getDayOfWeek(date);
-      var flags = {
-        d: d,
-        dd: pad(d),
-        ddd: dateFormat.i18n.dayNames[D],
-        dddd: dateFormat.i18n.dayNames[D + 7],
-        m: m + 1,
-        mm: pad(m + 1),
-        mmm: dateFormat.i18n.monthNames[m],
-        mmmm: dateFormat.i18n.monthNames[m + 12],
-        yy: String(y).slice(2),
-        yyyy: y,
-        h: H % 12 || 12,
-        hh: pad(H % 12 || 12),
-        H: H,
-        HH: pad(H),
-        M: M,
-        MM: pad(M),
-        s: s,
-        ss: pad(s),
-        l: pad(L, 3),
-        L: pad(Math.round(L / 10)),
-        t: H < 12 ? dateFormat.i18n.timeNames[0] : dateFormat.i18n.timeNames[1],
-        tt:
-          H < 12 ? dateFormat.i18n.timeNames[2] : dateFormat.i18n.timeNames[3],
-        T: H < 12 ? dateFormat.i18n.timeNames[4] : dateFormat.i18n.timeNames[5],
-        TT:
-          H < 12 ? dateFormat.i18n.timeNames[6] : dateFormat.i18n.timeNames[7],
-        Z: gmt
-          ? "GMT"
-          : utc
-          ? "UTC"
-          : (String(date).match(timezone) || [""])
-              .pop()
-              .replace(timezoneClip, ""),
-        o:
-          (o > 0 ? "-" : "+") +
-          pad(Math.floor(Math.abs(o) / 60) * 100 + (Math.abs(o) % 60), 4),
-        S: ["th", "st", "nd", "rd"][
-          d % 10 > 3 ? 0 : (((d % 100) - (d % 10) != 10) * d) % 10
-        ],
-        W: W,
-        N: N,
+      var _ = function _() {
+        return utc ? "getUTC" : "get";
       };
 
+      var _d = function d() {
+        return date[_() + "Date"]();
+      };
+
+      var D = function D() {
+        return date[_() + "Day"]();
+      };
+
+      var _m = function m() {
+        return date[_() + "Month"]();
+      };
+
+      var y = function y() {
+        return date[_() + "FullYear"]();
+      };
+
+      var _H = function H() {
+        return date[_() + "Hours"]();
+      };
+
+      var _M = function M() {
+        return date[_() + "Minutes"]();
+      };
+
+      var _s = function s() {
+        return date[_() + "Seconds"]();
+      };
+
+      var _L = function L() {
+        return date[_() + "Milliseconds"]();
+      };
+
+      var _o = function o() {
+        return utc ? 0 : date.getTimezoneOffset();
+      };
+
+      var _W = function W() {
+        return getWeek(date);
+      };
+
+      var _N = function N() {
+        return getDayOfWeek(date);
+      };
+
+      var flags = {
+        d: function d() {
+          return _d();
+        },
+        dd: function dd() {
+          return pad(_d());
+        },
+        ddd: function ddd() {
+          return dateFormat.i18n.dayNames[D()];
+        },
+        dddd: function dddd() {
+          return dateFormat.i18n.dayNames[D() + 7];
+        },
+        m: function m() {
+          return _m() + 1;
+        },
+        mm: function mm() {
+          return pad(_m() + 1);
+        },
+        mmm: function mmm() {
+          return dateFormat.i18n.monthNames[_m()];
+        },
+        mmmm: function mmmm() {
+          return dateFormat.i18n.monthNames[_m() + 12];
+        },
+        yy: function yy() {
+          return String(y()).slice(2);
+        },
+        yyyy: function yyyy() {
+          return y();
+        },
+        h: function h() {
+          return _H() % 12 || 12;
+        },
+        hh: function hh() {
+          return pad(_H() % 12 || 12);
+        },
+        H: function H() {
+          return _H();
+        },
+        HH: function HH() {
+          return pad(_H());
+        },
+        M: function M() {
+          return _M();
+        },
+        MM: function MM() {
+          return pad(_M());
+        },
+        s: function s() {
+          return _s();
+        },
+        ss: function ss() {
+          return pad(_s());
+        },
+        l: function l() {
+          return pad(_L(), 3);
+        },
+        L: function L() {
+          return pad(Math.round(_L() / 10));
+        },
+        t: function t() {
+          return _H() < 12
+            ? dateFormat.i18n.timeNames[0]
+            : dateFormat.i18n.timeNames[1];
+        },
+        tt: function tt() {
+          return _H() < 12
+            ? dateFormat.i18n.timeNames[2]
+            : dateFormat.i18n.timeNames[3];
+        },
+        T: function T() {
+          return _H() < 12
+            ? dateFormat.i18n.timeNames[4]
+            : dateFormat.i18n.timeNames[5];
+        },
+        TT: function TT() {
+          return _H() < 12
+            ? dateFormat.i18n.timeNames[6]
+            : dateFormat.i18n.timeNames[7];
+        },
+        Z: function Z() {
+          return gmt
+            ? "GMT"
+            : utc
+            ? "UTC"
+            : (String(date).match(timezone) || [""])
+                .pop()
+                .replace(timezoneClip, "")
+                .replace(/GMT\+0000/g, "UTC");
+        },
+        o: function o() {
+          return (
+            (_o() > 0 ? "-" : "+") +
+            pad(
+              Math.floor(Math.abs(_o()) / 60) * 100 + (Math.abs(_o()) % 60),
+              4
+            )
+          );
+        },
+        S: function S() {
+          return ["th", "st", "nd", "rd"][
+            _d() % 10 > 3 ? 0 : (((_d() % 100) - (_d() % 10) != 10) * _d()) % 10
+          ];
+        },
+        W: function W() {
+          return _W();
+        },
+        N: function N() {
+          return _N();
+        },
+      };
       return mask.replace(token, function (match) {
         if (match in flags) {
-          return flags[match];
+          return flags[match]();
         }
+
         return match.slice(1, match.length - 1);
       });
     };
@@ -135,9 +260,8 @@
     isoDateTime: "yyyy-mm-dd'T'HH:MM:sso",
     isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'",
     expiresHeaderFormat: "ddd, dd mmm yyyy HH:MM:ss Z",
-  };
+  }; // Internationalization strings
 
-  // Internationalization strings
   dateFormat.i18n = {
     dayNames: [
       "Sun",
@@ -187,12 +311,13 @@
   function pad(val, len) {
     val = String(val);
     len = len || 2;
+
     while (val.length < len) {
       val = "0" + val;
     }
+
     return val;
   }
-
   /**
    * Get the ISO 8601 week number
    * Based on comments from
@@ -201,37 +326,32 @@
    * @param  {Object} `date`
    * @return {Number}
    */
+
   function getWeek(date) {
     // Remove time components of date
     var targetThursday = new Date(
       date.getFullYear(),
       date.getMonth(),
       date.getDate()
-    );
+    ); // Change date to Thursday same week
 
-    // Change date to Thursday same week
     targetThursday.setDate(
       targetThursday.getDate() - ((targetThursday.getDay() + 6) % 7) + 3
-    );
+    ); // Take January 4th as it is always in week 1 (see ISO 8601)
 
-    // Take January 4th as it is always in week 1 (see ISO 8601)
-    var firstThursday = new Date(targetThursday.getFullYear(), 0, 4);
+    var firstThursday = new Date(targetThursday.getFullYear(), 0, 4); // Change date to Thursday same week
 
-    // Change date to Thursday same week
     firstThursday.setDate(
       firstThursday.getDate() - ((firstThursday.getDay() + 6) % 7) + 3
-    );
+    ); // Check if daylight-saving-time-switch occurred and correct for it
 
-    // Check if daylight-saving-time-switch occurred and correct for it
     var ds =
       targetThursday.getTimezoneOffset() - firstThursday.getTimezoneOffset();
-    targetThursday.setHours(targetThursday.getHours() - ds);
+    targetThursday.setHours(targetThursday.getHours() - ds); // Number of weeks between target Thursday and first Thursday
 
-    // Number of weeks between target Thursday and first Thursday
     var weekDiff = (targetThursday - firstThursday) / (86400000 * 7);
     return 1 + Math.floor(weekDiff);
   }
-
   /**
    * Get ISO-8601 numeric representation of the day of the week
    * 1 (for Monday) through 7 (for Sunday)
@@ -239,19 +359,22 @@
    * @param  {Object} `date`
    * @return {Number}
    */
+
   function getDayOfWeek(date) {
     var dow = date.getDay();
+
     if (dow === 0) {
       dow = 7;
     }
+
     return dow;
   }
-
   /**
    * kind-of shortcut
    * @param  {*} val
    * @return {String}
    */
+
   function kindOf(val) {
     if (val === null) {
       return "null";
@@ -261,8 +384,8 @@
       return "undefined";
     }
 
-    if (typeof val !== "object") {
-      return typeof val;
+    if (_typeof(val) !== "object") {
+      return _typeof(val);
     }
 
     if (Array.isArray(val)) {
@@ -276,9 +399,12 @@
     define(function () {
       return dateFormat;
     });
-  } else if (typeof exports === "object") {
+  } else if (
+    (typeof exports === "undefined" ? "undefined" : _typeof(exports)) ===
+    "object"
+  ) {
     module.exports = dateFormat;
   } else {
     global.dateFormat = dateFormat;
   }
-})(this);
+})(void 0);

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -252,13 +252,13 @@
    * @param  {Object} `date`
    * @return {Number}
    */
-  function getDayOfWeek(date) {
+  const getDayOfWeek = (date) => {
     var dow = date.getDay();
     if (dow === 0) {
       dow = 7;
     }
     return dow;
-  }
+  };
 
   /**
    * kind-of shortcut

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -197,14 +197,14 @@
     timeNames: ["a", "p", "am", "pm", "A", "P", "AM", "PM"],
   };
 
-  function pad(val, len) {
+  const pad = (val, len) => {
     val = String(val);
     len = len || 2;
     while (val.length < len) {
       val = "0" + val;
     }
     return val;
-  }
+  };
 
   /**
    * Get the ISO 8601 week number

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -15,7 +15,7 @@
 ((global) => {
   "use strict";
 
-  var dateFormat = (function () {
+  var dateFormat = (() => {
     var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|"[^"]*"|'[^']*'/g;
     var timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
     var timezoneClip = /[^-+\dA-Z]/g;

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -125,7 +125,7 @@
         N: () => N(),
       };
 
-      return mask.replace(token, function (match) {
+      return mask.replace(token, (match) => {
         if (match in flags) {
           return flags[match]();
         }

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -214,7 +214,7 @@
    * @param  {Object} `date`
    * @return {Number}
    */
-  function getWeek(date) {
+  const getWeek = (date) => {
     // Remove time components of date
     var targetThursday = new Date(
       date.getFullYear(),
@@ -243,7 +243,7 @@
     // Number of weeks between target Thursday and first Thursday
     var weekDiff = (targetThursday - firstThursday) / (86400000 * 7);
     return 1 + Math.floor(weekDiff);
-  }
+  };
 
   /**
    * Get ISO-8601 numeric representation of the day of the week

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -265,7 +265,7 @@
    * @param  {*} val
    * @return {String}
    */
-  function kindOf(val) {
+  const kindOf = (val) => {
     if (val === null) {
       return "null";
     }
@@ -283,7 +283,7 @@
     }
 
     return {}.toString.call(val).slice(8, -1).toLowerCase();
-  }
+  };
 
   if (typeof define === "function" && define.amd) {
     define(function () {

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -286,7 +286,7 @@
   };
 
   if (typeof define === "function" && define.amd) {
-    define(function () {
+    define(() => {
       return dateFormat;
     });
   } else if (typeof exports === "object") {

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -21,7 +21,7 @@
     var timezoneClip = /[^-+\dA-Z]/g;
 
     // Regexes and supporting functions are cached through closure
-    return function (date, mask, utc, gmt) {
+    return (date, mask, utc, gmt) => {
       // You can't provide utc if you skip other args (use the 'UTC:' mask prefix)
       if (
         arguments.length === 1 &&

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -12,7 +12,7 @@
  * The mask defaults to dateFormat.masks.default.
  */
 
-(function (global) {
+((global) => {
   "use strict";
 
   var dateFormat = (function () {

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -12,7 +12,7 @@
  * The mask defaults to dateFormat.masks.default.
  */
 
-((global) => {
+(function (global) {
   "use strict";
 
   var dateFormat = (() => {


### PR DESCRIPTION
Most functions used the older `function` declarations.  
To standardise throughout the project, and to adopt a more modern syntax, this moves to using arrow functions for all functions.

closes: #133 