### PR TITLE
Apply Padding to yyyy Mask

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -78,7 +78,7 @@
         mmm: () => dateFormat.i18n.monthNames[m()],
         mmmm: () => dateFormat.i18n.monthNames[m() + 12],
         yy: () => String(y()).slice(2),
-        yyyy: () => y(),
+        yyyy: () => pad(y(), 4),
         h: () => H() % 12 || 12,
         hh: () => pad(H() % 12 || 12),
         H: () => H(),

--- a/test/test_mask-yyyy.js
+++ b/test/test_mask-yyyy.js
@@ -22,4 +22,18 @@ describe("Mask: 'yyyy'", function () {
     assert.strictEqual(d, "1763");
     done();
   });
+
+  it("should format '0999-01-01' as '0999'", function (done) {
+    var date = new Date("0999-01-01");
+    var d = dateFormat(date, "yyyy");
+    assert.strictEqual(d, "0999");
+    done();
+  });
+
+  it("should format '0002-12-11' as '0002'", function (done) {
+    var date = new Date("0002-12-11");
+    var d = dateFormat(date, "yyyy");
+    assert.strictEqual(d, "0002");
+    done();
+  });
 });


### PR DESCRIPTION
Previously the yyyy mask would not pad the years before 1000.  
For example 0009 would display as 9.  
This changes this functionality so that it now always outputs as 4 long.  
It also ads some new tests for this functionality.

closes: #39