### PR TITLE
Fixed Invalid '1970-01-01' Formatting

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -32,7 +32,7 @@
         date = undefined;
       }
 
-      date = date || new Date();
+      date = date || date === 0 ? date : new Date();
 
       if (!(date instanceof Date)) {
         date = new Date(date);

--- a/test/test_isoutcdatetime.js
+++ b/test/test_isoutcdatetime.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
+var assert = require("assert");
 
-var dateFormat = require('./../lib/dateformat');
+var dateFormat = require("./../lib/dateformat");
 
-describe('isoUtcDateTime', function() {
-  it('should correctly format the timezone part', function(done) {
-    var actual = dateFormat('2014-06-02T13:23:21-08:00', 'isoUtcDateTime');
-    assert.strictEqual(actual, '2014-06-02T21:23:21Z');
+describe("isoUtcDateTime", function () {
+  it("should correctly format the timezone part", function (done) {
+    var actual = dateFormat("2014-06-02T13:23:21-08:00", "isoUtcDateTime");
+    assert.strictEqual(actual, "2014-06-02T21:23:21Z");
+    var epochTime = dateFormat(0, "isoUtcDateTime");
+    assert.strictEqual(epochTime, "1970-01-01T00:00:00Z");
     done();
   });
 });


### PR DESCRIPTION
Previously the date `1970-01-01` when when formatted would error and be set as the current date.  
This fixes that to keep the date that is passed through.

closes: #79