### PR TITLE
Added Padding Short Date Mask

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,9 +6,9 @@ A node.js package for Steven Levithan's excellent [dateFormat()][dateformat] fun
 
 ## Modifications
 
-* Removed the `Date.prototype.format` method. Sorry folks, but extending native prototypes is for suckers.
-* Added a `module.exports = dateFormat;` statement at the bottom
-* Added the placeholder `N` to get the ISO 8601 numeric representation of the day of the week
+- Removed the `Date.prototype.format` method. Sorry folks, but extending native prototypes is for suckers.
+- Added a `module.exports = dateFormat;` statement at the bottom
+- Added the placeholder `N` to get the ISO 8601 numeric representation of the day of the week
 
 ## Installation
 
@@ -20,8 +20,9 @@ $ dateformat --help
 ## Usage
 
 As taken from Steven's post, modified to match the Modifications listed above:
+
 ```js
-var dateFormat = require('dateformat');
+var dateFormat = require("dateformat");
 var now = new Date();
 
 // Basic usage
@@ -70,89 +71,125 @@ dateFormat(now, "W");
 // 42
 
 // and also get the ISO 8601 numeric representation of the day of the week:
-dateFormat(now,"N");
+dateFormat(now, "N");
 // 6
 ```
 
 ### Mask options
 
-Mask | Description
----- | -----------
-`d` | Day of the month as digits; no leading zero for single-digit days.
-`dd` | Day of the month as digits; leading zero for single-digit days.
-`ddd` | Day of the week as a three-letter abbreviation.
-`dddd` | Day of the week as its full name.
-`m` | Month as digits; no leading zero for single-digit months.
-`mm` | Month as digits; leading zero for single-digit months.
-`mmm` | Month as a three-letter abbreviation.
-`mmmm` | Month as its full name.
-`yy` | Year as last two digits; leading zero for years less than 10.
-`yyyy` | Year represented by four digits.
-`h` | Hours; no leading zero for single-digit hours (12-hour clock).
-`hh` | Hours; leading zero for single-digit hours (12-hour clock).
-`H` | Hours; no leading zero for single-digit hours (24-hour clock).
-`HH` | Hours; leading zero for single-digit hours (24-hour clock).
-`M` | Minutes; no leading zero for single-digit minutes.
-`MM` | Minutes; leading zero for single-digit minutes.
-`N` | ISO 8601 numeric representation of the day of the week.
-`o` | GMT/UTC timezone offset, e.g. -0500 or +0230.
-`s` | Seconds; no leading zero for single-digit seconds.
-`ss` | Seconds; leading zero for single-digit seconds.
-`S` | The date's ordinal suffix (st, nd, rd, or th). Works well with `d`.
-`l` |  Milliseconds; gives 3 digits.
-`L` | Milliseconds; gives 2 digits.
-`t`	| Lowercase, single-character time marker string: a or p.
-`tt` | Lowercase, two-character time marker string: am or pm.
-`T` | Uppercase, single-character time marker string: A or P.
-`TT` | Uppercase, two-character time marker string: AM or PM.
-`W` | ISO 8601 week number of the year, e.g. 42
-`Z` | US timezone abbreviation, e.g. EST or MDT. With non-US timezones or in the
-`'...'`, `"..."` | Literal character sequence. Surrounding quotes are removed.
-`UTC:` |	Must be the first four characters of the mask. Converts the date from local time to UTC/GMT/Zulu time before applying the mask. The "UTC:" prefix is removed.
+| Mask             | Description                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `d`              | Day of the month as digits; no leading zero for single-digit days.                                                                                            |
+| `dd`             | Day of the month as digits; leading zero for single-digit days.                                                                                               |
+| `ddd`            | Day of the week as a three-letter abbreviation.                                                                                                               |
+| `dddd`           | Day of the week as its full name.                                                                                                                             |
+| `m`              | Month as digits; no leading zero for single-digit months.                                                                                                     |
+| `mm`             | Month as digits; leading zero for single-digit months.                                                                                                        |
+| `mmm`            | Month as a three-letter abbreviation.                                                                                                                         |
+| `mmmm`           | Month as its full name.                                                                                                                                       |
+| `yy`             | Year as last two digits; leading zero for years less than 10.                                                                                                 |
+| `yyyy`           | Year represented by four digits.                                                                                                                              |
+| `h`              | Hours; no leading zero for single-digit hours (12-hour clock).                                                                                                |
+| `hh`             | Hours; leading zero for single-digit hours (12-hour clock).                                                                                                   |
+| `H`              | Hours; no leading zero for single-digit hours (24-hour clock).                                                                                                |
+| `HH`             | Hours; leading zero for single-digit hours (24-hour clock).                                                                                                   |
+| `M`              | Minutes; no leading zero for single-digit minutes.                                                                                                            |
+| `MM`             | Minutes; leading zero for single-digit minutes.                                                                                                               |
+| `N`              | ISO 8601 numeric representation of the day of the week.                                                                                                       |
+| `o`              | GMT/UTC timezone offset, e.g. -0500 or +0230.                                                                                                                 |
+| `s`              | Seconds; no leading zero for single-digit seconds.                                                                                                            |
+| `ss`             | Seconds; leading zero for single-digit seconds.                                                                                                               |
+| `S`              | The date's ordinal suffix (st, nd, rd, or th). Works well with `d`.                                                                                           |
+| `l`              | Milliseconds; gives 3 digits.                                                                                                                                 |
+| `L`              | Milliseconds; gives 2 digits.                                                                                                                                 |
+| `t`              | Lowercase, single-character time marker string: a or p.                                                                                                       |
+| `tt`             | Lowercase, two-character time marker string: am or pm.                                                                                                        |
+| `T`              | Uppercase, single-character time marker string: A or P.                                                                                                       |
+| `TT`             | Uppercase, two-character time marker string: AM or PM.                                                                                                        |
+| `W`              | ISO 8601 week number of the year, e.g. 42                                                                                                                     |
+| `Z`              | US timezone abbreviation, e.g. EST or MDT. With non-US timezones or in the                                                                                    |
+| `'...'`, `"..."` | Literal character sequence. Surrounding quotes are removed.                                                                                                   |
+| `UTC:`           | Must be the first four characters of the mask. Converts the date from local time to UTC/GMT/Zulu time before applying the mask. The "UTC:" prefix is removed. |
 
 ### Named Formats
 
-Name | Mask | Example
----- | ---- | -------
-`default` | `ddd mmm dd yyyy HH:MM:ss` | Sat Jun 09 2007 17:46:21
-`shortDate` | `m/d/yy` | 6/9/07
-`mediumDate` | `mmm d, yyyy` | Jun 9, 2007
-`longDate` | `mmmm d, yyyy` | June 9, 2007
-`fullDate` | `dddd, mmmm d, yyyy` | Saturday, June 9, 2007
-`shortTime` | `h:MM TT` | 5:46 PM
-`mediumTime` | `h:MM:ss TT` | 5:46:21 PM
-`longTime` | `h:MM:ss TT Z` | 5:46:21 PM EST
-`isoDate` | `yyyy-mm-dd` | 2007-06-09
-`isoTime` | `HH:MM:ss` | 17:46:21
-`isoDateTime` | `yyyy-mm-dd'T'HH:MM:ss` | 2007-06-09T17:46:21
-`isoUtcDateTime` | `UTC:yyyy-mm-dd'T'HH:MM:ss'Z'` | 2007-06-09T22:46:21Z
+| Name             | Mask                           | Example                  |
+| ---------------- | ------------------------------ | ------------------------ |
+| `default`        | `ddd mmm dd yyyy HH:MM:ss`     | Sat Jun 09 2007 17:46:21 |
+| `shortDate`      | `m/d/yy`                       | 6/9/07                   |
+| `mediumDate`     | `mmm d, yyyy`                  | Jun 9, 2007              |
+| `longDate`       | `mmmm d, yyyy`                 | June 9, 2007             |
+| `fullDate`       | `dddd, mmmm d, yyyy`           | Saturday, June 9, 2007   |
+| `shortTime`      | `h:MM TT`                      | 5:46 PM                  |
+| `mediumTime`     | `h:MM:ss TT`                   | 5:46:21 PM               |
+| `longTime`       | `h:MM:ss TT Z`                 | 5:46:21 PM EST           |
+| `isoDate`        | `yyyy-mm-dd`                   | 2007-06-09               |
+| `isoTime`        | `HH:MM:ss`                     | 17:46:21                 |
+| `isoDateTime`    | `yyyy-mm-dd'T'HH:MM:ss`        | 2007-06-09T17:46:21      |
+| `isoUtcDateTime` | `UTC:yyyy-mm-dd'T'HH:MM:ss'Z'` | 2007-06-09T22:46:21Z     |
 
 ### Localization
+
 Day names, month names and the AM/PM indicators can be localized by
 passing an object with the necessary strings. For example:
+
 ```js
-var dateFormat = require('dateformat');
+var dateFormat = require("dateformat");
 dateFormat.i18n = {
-    dayNames: [
-        'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat',
-        'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
-    ],
-    monthNames: [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-        'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'
-    ],
-    timeNames: [
-        'a', 'p', 'am', 'pm', 'A', 'P', 'AM', 'PM'
-    ]
+  dayNames: [
+    "Sun",
+    "Mon",
+    "Tue",
+    "Wed",
+    "Thu",
+    "Fri",
+    "Sat",
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ],
+  monthNames: [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+  timeNames: ["a", "p", "am", "pm", "A", "P", "AM", "PM"],
 };
 ```
+
 > Notice that only one language is supported at a time and all strings
-> *must* be present in the new value.
+> _must_ be present in the new value.
 
 ### Breaking change in 2.1.0
+
 - 2.1.0 was published with a breaking change, for those using localized strings.
 - 2.2.0 has been published without the change, to keep packages refering to ^2.0.0 to continue working. This is now branch v2_2.
-- 3.0.* contains the localized AM/PM change.
+- 3.0.\* contains the localized AM/PM change.
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -113,20 +113,21 @@ dateFormat(now, "N");
 
 ### Named Formats
 
-| Name             | Mask                           | Example                  |
-| ---------------- | ------------------------------ | ------------------------ |
-| `default`        | `ddd mmm dd yyyy HH:MM:ss`     | Sat Jun 09 2007 17:46:21 |
-| `shortDate`      | `m/d/yy`                       | 6/9/07                   |
-| `mediumDate`     | `mmm d, yyyy`                  | Jun 9, 2007              |
-| `longDate`       | `mmmm d, yyyy`                 | June 9, 2007             |
-| `fullDate`       | `dddd, mmmm d, yyyy`           | Saturday, June 9, 2007   |
-| `shortTime`      | `h:MM TT`                      | 5:46 PM                  |
-| `mediumTime`     | `h:MM:ss TT`                   | 5:46:21 PM               |
-| `longTime`       | `h:MM:ss TT Z`                 | 5:46:21 PM EST           |
-| `isoDate`        | `yyyy-mm-dd`                   | 2007-06-09               |
-| `isoTime`        | `HH:MM:ss`                     | 17:46:21                 |
-| `isoDateTime`    | `yyyy-mm-dd'T'HH:MM:ss`        | 2007-06-09T17:46:21      |
-| `isoUtcDateTime` | `UTC:yyyy-mm-dd'T'HH:MM:ss'Z'` | 2007-06-09T22:46:21Z     |
+| Name              | Mask                           | Example                  |
+| ----------------- | ------------------------------ | ------------------------ |
+| `default`         | `ddd mmm dd yyyy HH:MM:ss`     | Sat Jun 09 2007 17:46:21 |
+| `shortDate`       | `m/d/yy`                       | 6/9/07                   |
+| `paddedShortDate` | `mm/dd/yyyy`                   | 06/09/2007               |
+| `mediumDate`      | `mmm d, yyyy`                  | Jun 9, 2007              |
+| `longDate`        | `mmmm d, yyyy`                 | June 9, 2007             |
+| `fullDate`        | `dddd, mmmm d, yyyy`           | Saturday, June 9, 2007   |
+| `shortTime`       | `h:MM TT`                      | 5:46 PM                  |
+| `mediumTime`      | `h:MM:ss TT`                   | 5:46:21 PM               |
+| `longTime`        | `h:MM:ss TT Z`                 | 5:46:21 PM EST           |
+| `isoDate`         | `yyyy-mm-dd`                   | 2007-06-09               |
+| `isoTime`         | `HH:MM:ss`                     | 17:46:21                 |
+| `isoDateTime`     | `yyyy-mm-dd'T'HH:MM:ss`        | 2007-06-09T17:46:21      |
+| `isoUtcDateTime`  | `UTC:yyyy-mm-dd'T'HH:MM:ss'Z'` | 2007-06-09T22:46:21Z     |
 
 ### Localization
 

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -137,6 +137,7 @@
   dateFormat.masks = {
     default: "ddd mmm dd yyyy HH:MM:ss",
     shortDate: "m/d/yy",
+    paddedShortDate: "mm/dd/yyyy",
     mediumDate: "mmm d, yyyy",
     longDate: "mmmm d, yyyy",
     fullDate: "dddd, mmmm d, yyyy",

--- a/test/test_formats.js
+++ b/test/test_formats.js
@@ -1,38 +1,38 @@
-var assert = require('assert');
+var assert = require("assert");
 
-var _ = require('underscore');
+var _ = require("underscore");
 
-var dateFormat = require('../lib/dateformat');
+var dateFormat = require("../lib/dateformat");
 
 var expects = {
-  'default':               'Wed Nov 26 2014 13:19:44',
-  'shortDate':             '11/26/14',
-  'mediumDate':            'Nov 26, 2014',
-  'longDate':              'November 26, 2014',
-  'fullDate':              'Wednesday, November 26, 2014',
-  'shortTime':             '1:19 PM',
-  'mediumTime':            '1:19:44 PM',
-  'longTime':              '1:19:44 PM %TZ_PREFIX%%TZ_OFFSET%',
-  'isoDate':               '2014-11-26',
-  'isoTime':               '13:19:44',
-  'isoDateTime':           '2014-11-26T13:19:44%TZ_OFFSET%',
-  'isoUtcDateTime':        '',
-  'expiresHeaderFormat':   'Wed, 26 Nov 2014 13:19:44 %TZ_PREFIX%%TZ_OFFSET%'
+  default: "Wed Nov 26 2014 13:19:44",
+  shortDate: "11/26/14",
+  mediumDate: "Nov 26, 2014",
+  longDate: "November 26, 2014",
+  fullDate: "Wednesday, November 26, 2014",
+  shortTime: "1:19 PM",
+  mediumTime: "1:19:44 PM",
+  longTime: "1:19:44 PM %TZ_PREFIX%%TZ_OFFSET%",
+  isoDate: "2014-11-26",
+  isoTime: "13:19:44",
+  isoDateTime: "2014-11-26T13:19:44%TZ_OFFSET%",
+  isoUtcDateTime: "",
+  expiresHeaderFormat: "Wed, 26 Nov 2014 13:19:44 %TZ_PREFIX%%TZ_OFFSET%",
 };
 
 function pad(num, size) {
-    var s = num + '';
-    while (s.length < size) {
-      s = '0' + s;
-    }
-    return s;
+  var s = num + "";
+  while (s.length < size) {
+    s = "0" + s;
+  }
+  return s;
 }
 
 function parseOffset(date) {
   var offset = date.getTimezoneOffset();
-  var hours = Math.floor(-1 * offset / 60);
-  var minutes = (-1 * offset) - (hours * 60);
-  var sign = offset > 0 ? '-' : '+';
+  var hours = Math.floor((-1 * offset) / 60);
+  var minutes = -1 * offset - hours * 60;
+  var sign = offset > 0 ? "-" : "+";
   return {
     offset: offset,
     hours: hours,
@@ -46,28 +46,31 @@ function timezoneOffset(date) {
   return offset.sign + pad(offset.hours, 2) + pad(offset.minutes, 2);
 }
 
-describe('dateformat([now], [mask])', function() {
-  _.each(dateFormat.masks, function(value, key) {
-    it('should format `' + key + '` mask', function(done) {
+describe("dateformat([now], [mask])", function () {
+  _.each(dateFormat.masks, function (value, key) {
+    it("should format `" + key + "` mask", function (done) {
       var now = new Date(2014, 10, 26, 13, 19, 44);
       var tzOffset = timezoneOffset(now);
-      var expected = expects[key].replace(/%TZ_PREFIX%/, 'GMT')
-                                 .replace(/%TZ_OFFSET%/g, tzOffset)
-                                 .replace(/GMT\+0000/g, 'UTC');
-      if (key === 'isoUtcDateTime') {
+      var expected = expects[key]
+        .replace(/%TZ_PREFIX%/, "GMT")
+        .replace(/%TZ_OFFSET%/g, tzOffset)
+        .replace(/GMT\+0000/g, "UTC");
+      if (key === "isoUtcDateTime") {
         var offset = parseOffset(now);
-        now.setHours(now.getHours() - offset.hours,
-                     now.getMinutes() - offset.minutes);
-        var expected = now.toISOString().replace(/\.000/g, '');
+        now.setHours(
+          now.getHours() - offset.hours,
+          now.getMinutes() - offset.minutes
+        );
+        var expected = now.toISOString().replace(/\.000/g, "");
       }
       var actual = dateFormat(now, key);
       assert.strictEqual(actual, expected);
       done();
     });
   });
-  it('should use `default` mask, when `mask` is empty', function(done) {
+  it("should use `default` mask, when `mask` is empty", function (done) {
     var now = new Date(2014, 10, 26, 13, 19, 44);
-    var expected = expects['default'];
+    var expected = expects["default"];
     var actual = dateFormat(now);
 
     assert.strictEqual(actual, expected);

--- a/test/test_formats.js
+++ b/test/test_formats.js
@@ -5,19 +5,20 @@ var _ = require("underscore");
 var dateFormat = require("../lib/dateformat");
 
 var expects = {
-  default: "Wed Nov 26 2014 13:19:44",
-  shortDate: "11/26/14",
-  mediumDate: "Nov 26, 2014",
-  longDate: "November 26, 2014",
-  fullDate: "Wednesday, November 26, 2014",
+  default: "Sat Mar 08 2014 13:19:44",
+  shortDate: "3/8/14",
+  paddedShortDate: "03/08/2014",
+  mediumDate: "Mar 8, 2014",
+  longDate: "March 8, 2014",
+  fullDate: "Saturday, March 8, 2014",
   shortTime: "1:19 PM",
   mediumTime: "1:19:44 PM",
   longTime: "1:19:44 PM %TZ_PREFIX%%TZ_OFFSET%",
-  isoDate: "2014-11-26",
+  isoDate: "2014-03-08",
   isoTime: "13:19:44",
-  isoDateTime: "2014-11-26T13:19:44%TZ_OFFSET%",
+  isoDateTime: "2014-03-08T13:19:44%TZ_OFFSET%",
   isoUtcDateTime: "",
-  expiresHeaderFormat: "Wed, 26 Nov 2014 13:19:44 %TZ_PREFIX%%TZ_OFFSET%",
+  expiresHeaderFormat: "Sat, 08 Mar 2014 13:19:44 %TZ_PREFIX%%TZ_OFFSET%",
 };
 
 function pad(num, size) {
@@ -49,7 +50,7 @@ function timezoneOffset(date) {
 describe("dateformat([now], [mask])", function () {
   _.each(dateFormat.masks, function (value, key) {
     it("should format `" + key + "` mask", function (done) {
-      var now = new Date(2014, 10, 26, 13, 19, 44);
+      var now = new Date(2014, 2, 8, 13, 19, 44);
       var tzOffset = timezoneOffset(now);
       var expected = expects[key]
         .replace(/%TZ_PREFIX%/, "GMT")
@@ -69,7 +70,7 @@ describe("dateformat([now], [mask])", function () {
     });
   });
   it("should use `default` mask, when `mask` is empty", function (done) {
-    var now = new Date(2014, 10, 26, 13, 19, 44);
+    var now = new Date(2014, 2, 8, 13, 19, 44);
     var expected = expects["default"];
     var actual = dateFormat(now);
 


### PR DESCRIPTION
Previously there was an example mask format for all main formats other than the padding short format.  
Adding this mask type includes some useful utility, while also giving a good example of the padded format.

closes: #144