### PR TITLE
Fix Rounding Issue with L Mask

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -88,7 +88,7 @@
         s: () => s(),
         ss: () => pad(s()),
         l: () => pad(L(), 3),
-        L: () => pad(Math.round(L() / 10)),
+        L: () => pad(Math.floor(L() / 10)),
         t: () =>
           H() < 12
             ? dateFormat.i18n.timeNames[0]

--- a/test/test_mask-l_.js
+++ b/test/test_mask-l_.js
@@ -5,7 +5,7 @@ describe("Mask: 'L'", function () {
   it("should format '2020-10-10T08:48:02.436' as '44'", function (done) {
     var date = new Date("2020-10-10T08:48:02.436");
     var d = dateFormat(date, "L");
-    assert.strictEqual(d, "44");
+    assert.strictEqual(d, "43");
     done();
   });
 
@@ -24,7 +24,13 @@ describe("Mask: 'L'", function () {
 
   it("should format '2002-12-25T19:35:55.655' as '66'", function (done) {
     var d = dateFormat("2002-12-25T19:35:55.655", "L");
-    assert.strictEqual(d, "66");
+    assert.strictEqual(d, "65");
+    done();
+  });
+
+  it("should format '2126-07-23T03:15:25.999' as '99'", function (done) {
+    var d = dateFormat("2126-07-23T03:15:25.999", "L");
+    assert.strictEqual(d, "99");
     done();
   });
 });


### PR DESCRIPTION
Format mask `L` is documented as `Milliseconds; gives 2 digits`.  
However, the previous implementation outputs 3 digits when millisecond is between 995-999.  
This is because we used `Math.round` which would round it up to `100`.  
This was fixed by instead using `Math.floor`.

closes: #146
closes: #89