### PR TITLE
Adding `p` as timezone offset, e.g. `+02:00`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ dateFormat(now, "N");
 | `MM`             | Minutes; leading zero for single-digit minutes.                                                                                                               |
 | `N`              | ISO 8601 numeric representation of the day of the week.                                                                                                       |
 | `o`              | GMT/UTC timezone offset, e.g. -0500 or +0230.                                                                                                                 |
+| `p`              | GMT/UTC timezone offset, e.g. -05:00 or +02:30.                                                                                                               |
 | `s`              | Seconds; no leading zero for single-digit seconds.                                                                                                            |
 | `ss`             | Seconds; leading zero for single-digit seconds.                                                                                                               |
 | `S`              | The date's ordinal suffix (st, nd, rd, or th). Works well with `d`.                                                                                           |
@@ -126,7 +127,7 @@ dateFormat(now, "N");
 | `longTime`        | `h:MM:ss TT Z`                 | 5:46:21 PM EST           |
 | `isoDate`         | `yyyy-mm-dd`                   | 2007-06-09               |
 | `isoTime`         | `HH:MM:ss`                     | 17:46:21                 |
-| `isoDateTime`     | `yyyy-mm-dd'T'HH:MM:ss`        | 2007-06-09T17:46:21      |
+| `isoDateTime`     | `yyyy-mm-dd'T'HH:MM:sso`       | 2007-06-09T17:46:21+0700 |
 | `isoUtcDateTime`  | `UTC:yyyy-mm-dd'T'HH:MM:ss'Z'` | 2007-06-09T22:46:21Z     |
 
 ### Localization

--- a/benchmark/previousDateFormat.js
+++ b/benchmark/previousDateFormat.js
@@ -36,7 +36,7 @@ function _typeof(obj) {
   "use strict";
 
   var dateFormat = (function () {
-    var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|"[^"]*"|'[^']*'/g;
+    var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LlopSZWN]|"[^"]*"|'[^']*'/g;
     var timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
     var timezoneClip = /[^-+\dA-Z]/g; // Regexes and supporting functions are cached through closure
 
@@ -222,6 +222,14 @@ function _typeof(obj) {
               Math.floor(Math.abs(_o()) / 60) * 100 + (Math.abs(_o()) % 60),
               4
             )
+          );
+        },
+        p: function p() {
+          return (
+            (_o() > 0 ? "-" : "+") +
+            pad(Math.floor(Math.abs(_o()) / 60), 2) +
+            ':' +
+            pad(Math.floor(Math.abs(_o()) % 60), 2)
           );
         },
         S: function S() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dateformat",
-  "version": "4.0.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3411,12 +3411,7 @@
     "uglify-js": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
-      "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ=="
-    },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -16,7 +16,7 @@
   "use strict";
 
   const dateFormat = (() => {
-    const token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZWN]|"[^"]*"|'[^']*'/g;
+    const token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LlopSZWN]|"[^"]*"|'[^']*'/g;
     const timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
     const timezoneClip = /[^-+\dA-Z]/g;
 
@@ -117,6 +117,11 @@
         o: () =>
           (o() > 0 ? "-" : "+") +
           pad(Math.floor(Math.abs(o()) / 60) * 100 + (Math.abs(o()) % 60), 4),
+        p: () =>
+          (o() > 0 ? "-" : "+") +
+          pad(Math.floor(Math.abs(o()) / 60), 2) +
+          ':' +
+          pad(Math.floor(Math.abs(o()) % 60), 2),
         S: () =>
           ["th", "st", "nd", "rd"][
             d() % 10 > 3 ? 0 : (((d() % 100) - (d() % 10) != 10) * d()) % 10

--- a/test/test_mask-o.js
+++ b/test/test_mask-o.js
@@ -1,0 +1,11 @@
+var assert = require("assert");
+var dateFormat = require("../lib/dateformat");
+
+describe("Mask: 'o'", function () {
+  it("should get timezone for any date as smoething like [+-]XXXX", function (done) {
+    var date = new Date();
+    var d = dateFormat(date, "o");
+    assert.ok(d.match(/^[+-]\d{4}$/), d);
+    done();
+  });
+});

--- a/test/test_mask-p.js
+++ b/test/test_mask-p.js
@@ -1,0 +1,11 @@
+var assert = require("assert");
+var dateFormat = require("../lib/dateformat");
+
+describe("Mask: 'p'", function () {
+  it("should get timezone for any date as smoething like [+-]XX:XX", function (done) {
+    var date = new Date();
+    var d = dateFormat(date, "p");
+    assert.ok(d.match(/^[+-]\d{2}:\d{2}$/), d);
+    done();
+  });
+});


### PR DESCRIPTION
Because the feed validator for ATOM complains about timezone offset being given as `+0200` and not as `+02:00`, I added a slight modification of the `o` and called it `p` (like in PHP's date function).

I ended up killing my original pull request at https://github.com/felixge/node-dateformat/pull/56 (please close that) and building a completely new fix.

Cheers & thanks for this great lib,
Frank

closes: #148
closes: #81