### PR TITLE
Fix broken timezone abbreviations and GMT fallback

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -14,7 +14,7 @@
 
 // Regexes and supporting functions are cached through closure
 const token = /d{1,4}|D{3,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|W{1,2}|[LlopSZN]|"[^"]*"|'[^']*'/g;
-const timezone = /\b((?:[PMCEA][SDP][TC])(?:[-+]\d{4})?|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time)\b/g;
+const timezone = /\b(?:[A-Z]{1,3}[A-Z][TC])(?:[-+]\d{4})?|((?:Australian )?(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time)\b/g;
 const timezoneClip = /[^-+\dA-Z]/g;
 
 /**
@@ -128,10 +128,7 @@ export default function dateFormat (date, mask, utc, gmt) {
         ? "GMT"
         : utc
           ? "UTC"
-          : (String(date).match(timezone) || [""])
-            .pop()
-            .replace(timezoneClip, "")
-            .replace(/GMT\+0000/g, "UTC"),
+          : formatTimezone(date),
     o: () =>
       (o() > 0 ? "-" : "+") +
       pad(Math.floor(Math.abs(o()) / 60) * 100 + (Math.abs(o()) % 60), 4),
@@ -309,4 +306,21 @@ const getDayOfWeek = (date) => {
     dow = 7;
   }
   return dow;
+};
+
+/**
+ * Get proper timezone abbreviation or timezone offset.
+ * 
+ * This will fall back to `GMT+xxxx` if it does not recognize the
+ * timezone within the `timezone` RegEx above. Currently only common
+ * American and Australian timezone abbreviations are supported.
+ * 
+ * @param  {String | Date} date
+ * @return {String}
+ */
+export const formatTimezone = (date) => {
+  return (String(date).match(timezone) || [""])
+    .pop()
+    .replace(timezoneClip, "")
+    .replace(/GMT\+0000/g, "UTC");
 };

--- a/test/test_mask-z_.js
+++ b/test/test_mask-z_.js
@@ -1,0 +1,47 @@
+import { strictEqual } from "node:assert";
+import { formatTimezone } from "../lib/dateformat.js";
+
+describe("Mask: 'Z'", function () {
+  it("should format 'Tue Sep 08 2020 13:26:11 GMT-0500 (Central Daylight Time)' as 'CDT'", function (done) {
+    var d = formatTimezone("Tue Sep 08 2020 13:26:11 GMT-0500 (Central Daylight Time)");
+    strictEqual(d, "CDT");
+    done();
+  });
+
+  it("should format 'Tue Sep 08 2020 12:26:11 GMT-0600 (Mountain Daylight Time)' as 'MDT'", function (done) {
+    var d = formatTimezone("Tue Sep 08 2020 12:26:11 GMT-0600 (Mountain Daylight Time)");
+    strictEqual(d, "MDT");
+    done();
+  });
+
+  it("should format 'Wed Sep 09 2020 04:28:21 GMT+1000 (Australian Eastern Standard Time)' as 'AEST'", function (done) {
+    var d = formatTimezone("Wed Sep 09 2020 04:28:21 GMT+1000 (Australian Eastern Standard Time)");
+    strictEqual(d, "AEST");
+    done();
+  });
+
+  it("should format 'Wed Sep 09 2020 03:56:05 GMT+0930 (Australian Central Standard Time)' as 'ACST'", function (done) {
+    var d = formatTimezone("Wed Sep 09 2020 03:56:05 GMT+0930 (Australian Central Standard Time)");
+    strictEqual(d, "ACST");
+    done();
+  });
+
+  it("should format 'Tue Feb 02 2021 09:51:33 GMT+1030 (Australian Central Daylight Time)' as 'ACDT'", function (done) {
+    var d = formatTimezone("Tue Feb 02 2021 09:51:33 GMT+1030 (Australian Central Daylight Time)");
+    strictEqual(d, "ACDT");
+    done();
+  });
+
+  /* Since CEST is not currently supported abbreviation we fall back to GMT+xxxx */
+  it("should format 'Tue Feb 02 2021 00:21:33 GMT+0100 (Central European Standard Time)' as 'GMT+0100' (fallback)", function (done) {
+    var d = formatTimezone("Tue Feb 02 2021 00:21:33 GMT+0100 (Central European Standard Time)");
+    strictEqual(d, "GMT+0100");
+    done();
+  });
+
+  it("should format 'Tue Sep 08 2020 20:26:22 GMT+0200 (Central European Summer Time)' as 'GMT+0200' (fallback)", function (done) {
+    var d = formatTimezone("Tue Sep 08 2020 20:26:22 GMT+0200 (Central European Summer Time)");
+    strictEqual(d, "GMT+0200");
+    done();
+  });
+});


### PR DESCRIPTION
This PR aims to fix what both #104 and #165 attempted to do, this time with tests to ensure it works as expected and doesn't break in the future.

The gist is this:

The `Z` formatting option attempts to generate a nice timezone abbreviation by parsing the rendered date string, recognizing something like "Eastern Daylight Time" and changing that to `EDT`. For all unrecognized timezones (pretty much everything but common North American timezones) it would parse and display the `GMT+xxxx` offset from the date string instead.

This, however caused a couple of issues with Australian timezones. Because Australia has defined an "Australian Eastern Daylight Time" (for instance) it would erroneously match the same regex as the American "Eastern Daylight Time" and it would render as `EST` instead of `AEST`.  Adding explicit support for the `"Australian "` prefix fixes this issue.

The `GMT+xxxx` fallback worked prior to #165 but it was broken, probably accidentally while rebasing #104 in an attempt to get it into a merge-able state. This PR fixes the issue introduced by #165 and adds some tests to ensure it doesn't get inadvertently broken in the future.

/cc @chase-manning 