### PR TITLE
Fix file extension in main field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "5.0.1",
   "license": "MIT",
   "type": "module",
-  "main": "lib/dateformat",
+  "main": "lib/dateformat.js",
   "devDependencies": {
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
This adds the `.js` file extension to the value of the "main" field in `package.json`, which is required since this package uses ES modules. 

This fixes the deprecation warning: "Automatic extension resolution of the "main" field is deprecated for ES modules."

Fixes #175